### PR TITLE
Update gitignore and README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,22 @@
-project.godot
+
+# Godot-specific ignores
 .import/
+export.cfg
+export_presets.cfg
+
+# Imported translations (automatically generated from CSV files)
+*.translation
+
+# Mono-specific ignores
+.mono/
+data_*/
+mono_crash.*.json
+
+# System/tool-specific ignores
+.directory
+*~
+project.godot
 Test Workbench/
 default_bus_layout.tres
+default_env.tres
 *.import

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Audio Effect Inspector Godot Addon
-![icon](https://github.com/NoodleSushi/AudioEffectInspector_GodotAddon/blob/master/addons/AudioEffectInspector/icon.png?raw=true)
-![Preview](https://github.com/NoodleSushi/AudioEffectInspector_GodotAddon/blob/master/README%20Content/Preview.png?raw=true)
+![icon](addons/AudioEffectInspector/icon.png)
+![Preview](README%20Content/Preview.png)
 Audio Effects could be confusing to users who may be unfamiliar with the Audio Engineering environment and its tools. Looking at sliders with no visual feedback may seem a little daunting. This is where the Audio Effect Inspector comes in handy! It enables you to control your tools much easier with a graphical interface; like any VST plugin used in DAWs.
 
 [![Kofi Logo](https://az743702.vo.msecnd.net/cdn/kofi1.png?v=0)](https://ko-fi.com/noodlesushidev)
 
 ## AudioEffectEQ
-![AudioEffectEQ](https://github.com/NoodleSushi/AudioEffectInspector_GodotAddon/blob/master/README%20Content/AudioEffectEQ.gif?raw=true)
+![AudioEffectEQ](README%20Content/AudioEffectEQ.gif)
 
 ## AudioEffectReverb
-![AudioEffectReverb](https://github.com/NoodleSushi/AudioEffectInspector_GodotAddon/blob/master/README%20Content/AudioEffectReverb.gif?raw=true)
+![AudioEffectReverb](README%20Content/AudioEffectReverb.gif)
 
 ## AudioEffectDelay
-![AudioEffectDelay](https://github.com/NoodleSushi/AudioEffectInspector_GodotAddon/blob/master/README%20Content/AudioEffectDelay.gif?raw=true)
+![AudioEffectDelay](README%20Content/AudioEffectDelay.gif)
 
 ## AudioEffectPanner
-![AudioEffectPanner](https://github.com/NoodleSushi/AudioEffectInspector_GodotAddon/blob/master/README%20Content/AudioEffectPanner.gif?raw=true)
+![AudioEffectPanner](README%20Content/AudioEffectPanner.gif)


### PR DESCRIPTION
I updated the gitignore to be based on other Godot gitignores. Since I noticed you're ignoring Godot project files, I also added `default_env.tres` in the gitignore.

Also, use relative links in the README.